### PR TITLE
add token fields and track message offsets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,7 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+*.offset
+*.pickle
+
 vendor/

--- a/config.go
+++ b/config.go
@@ -196,6 +196,7 @@ func (c Config) loadWebsocketConnector() error {
 
 	cfg := transport.WebsocketConfig{
 		MessagingURL: c.MessagingURL,
+		StorageDir:   c.StorageDir,
 		SelfID:       c.SelfAppID,
 		DeviceID:     c.DeviceID,
 		PrivateKey:   c.sk,

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,7 @@ github.com/skip2/go-qrcode v0.0.0-20191027152451-9434209cb086 h1:RYiqpb2ii2Z6J4x
 github.com/skip2/go-qrcode v0.0.0-20191027152451-9434209cb086/go.mod h1:PLPIyL7ikehBD1OAjmKKiOEhbvWyHGaNDjquXMcYABo=
 github.com/square/go-jose v2.4.1+incompatible h1:KFYc54wTtgnd3x4B/Y7Zr1s/QaEx2BNzRsB3Hae5LHo=
 github.com/square/go-jose v2.4.1+incompatible/go.mod h1:7MxpAF/1WTVUu8Am+T5kNy+t0902CaLWM4Z745MkOa8=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=

--- a/messaging/acl.go
+++ b/messaging/acl.go
@@ -4,18 +4,21 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/selfid-net/self-go-sdk/pkg/ntp"
 	"github.com/google/uuid"
+	"github.com/selfid-net/self-go-sdk/pkg/ntp"
 	"github.com/square/go-jose"
 )
 
 // PermitConnection permits messages from a self ID
 func (c Service) PermitConnection(selfID string) error {
 	payload, err := json.Marshal(map[string]string{
+		"jti":        uuid.New().String(),
+		"cid":        uuid.New().String(),
+		"typ":        "acl.permit",
 		"iss":        c.selfID,
+		"sub":        c.selfID,
 		"iat":        ntp.TimeFunc().Format(time.RFC3339),
 		"exp":        ntp.TimeFunc().Add(time.Minute).Format(time.RFC3339),
-		"jti":        uuid.New().String(),
 		"acl_source": selfID,
 	})
 
@@ -43,10 +46,13 @@ func (c Service) PermitConnection(selfID string) error {
 // RevokeConnection denies and removes any exisitng permissions for a self ID
 func (c Service) RevokeConnection(selfID string) error {
 	payload, err := json.Marshal(map[string]string{
+		"jti":        uuid.New().String(),
+		"cid":        uuid.New().String(),
+		"typ":        "acl.revoke",
 		"iss":        c.selfID,
+		"sub":        c.selfID,
 		"iat":        ntp.TimeFunc().Format(time.RFC3339),
 		"exp":        ntp.TimeFunc().Add(time.Minute).Format(time.RFC3339),
-		"jti":        uuid.New().String(),
 		"acl_source": selfID,
 	})
 

--- a/pkg/transport/utils.go
+++ b/pkg/transport/utils.go
@@ -8,8 +8,8 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/selfid-net/self-go-sdk/pkg/ntp"
 	"github.com/google/uuid"
+	"github.com/selfid-net/self-go-sdk/pkg/ntp"
 	"github.com/square/go-jose"
 )
 
@@ -22,7 +22,10 @@ var (
 func GenerateToken(selfID string, sk ed25519.PrivateKey) (string, error) {
 	claims, err := json.Marshal(map[string]interface{}{
 		"jti": uuid.New().String(),
+		"cid": uuid.New().String(),
+		"typ": "auth.token",
 		"iss": selfID,
+		"sub": selfID,
 		"iat": ntp.TimeFunc().Add(-(time.Second * 5)).Unix(),
 		"exp": ntp.TimeFunc().Add(time.Minute).Unix(),
 	})

--- a/pkg/transport/websocket.go
+++ b/pkg/transport/websocket.go
@@ -243,6 +243,7 @@ func (c *Websocket) connect() error {
 		Type:   msgproto.MsgType_AUTH,
 		Token:  token,
 		Device: c.config.DeviceID,
+		Offset: uint64(c.offset),
 	}
 
 	data, err := proto.Marshal(&auth)
@@ -359,10 +360,9 @@ func (c *Websocket) reader() {
 			offsetData := make([]byte, 8)
 			binary.LittleEndian.PutUint64(offsetData, uint64(c.offset))
 
-			_, err = c.ofd.WriteAt(offsetData, 0)
+			_, err = c.ofd.Write(offsetData)
 			if err != nil {
-				log.Println(err)
-				continue
+				log.Fatal(err)
 			}
 
 			c.inbox <- m

--- a/pkg/transport/websocket_test.go
+++ b/pkg/transport/websocket_test.go
@@ -18,7 +18,8 @@ func TestWebsocketConnect(t *testing.T) {
 		DeviceID:     "1",
 		PrivateKey:   sk,
 		MessagingURL: s.endpoint,
-		TCPDeadline:  time.Millisecond * 10,
+		TCPDeadline:  time.Millisecond * 100,
+		InboxSize:    128,
 	}
 
 	c, err := NewWebsocket(cfg)
@@ -38,7 +39,8 @@ func TestWebsocketReconnect(t *testing.T) {
 		DeviceID:     "1",
 		PrivateKey:   sk,
 		MessagingURL: s.endpoint,
-		TCPDeadline:  time.Millisecond * 10,
+		TCPDeadline:  time.Second,
+		InboxSize:    128,
 		OnConnect: func() {
 			connected <- true
 		},
@@ -49,7 +51,7 @@ func TestWebsocketReconnect(t *testing.T) {
 
 	c, err := NewWebsocket(cfg)
 	require.Nil(t, err)
-	require.Nil(t, c.Close())
+	defer c.Close()
 
 	assert.True(t, <-connected)
 
@@ -72,7 +74,8 @@ func TestWebsocketSend(t *testing.T) {
 		DeviceID:     "1",
 		PrivateKey:   sk,
 		MessagingURL: s.endpoint,
-		TCPDeadline:  time.Millisecond * 10,
+		TCPDeadline:  time.Millisecond * 100,
+		InboxSize:    128,
 	}
 
 	c, err := NewWebsocket(cfg)
@@ -100,7 +103,8 @@ func TestWebsocketReceive(t *testing.T) {
 		DeviceID:     "1",
 		PrivateKey:   sk,
 		MessagingURL: s.endpoint,
-		TCPDeadline:  time.Millisecond * 10,
+		TCPDeadline:  time.Millisecond * 100,
+		InboxSize:    128,
 	}
 
 	c, err := NewWebsocket(cfg)


### PR DESCRIPTION
- [x] Update Auth Token payload to include standard fields
- [x] Update ACL request payload to include standard fields
- [x] Track offset of each message received and persist it to a file
- [x] Fix websocket reconnect tests